### PR TITLE
goのdockerfileにて、buildと実行を分けた

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,6 +44,7 @@ services:
   
   jojihouse-system:
     build: ./entrance-system
+    command: ./entrance-system/main
     container_name: jojihouse-system
     ports:
       - "8080:8080"

--- a/compose.yml
+++ b/compose.yml
@@ -44,7 +44,6 @@ services:
   
   jojihouse-system:
     build: ./entrance-system
-    command: ./entrance-system/main
     container_name: jojihouse-system
     ports:
       - "8080:8080"
@@ -64,8 +63,6 @@ services:
       - MONGO_HOST=mongoDb
       - MONGO_PORT=27017
     restart: always
-    volumes: 
-      - ./entrance-system:/go/src
     tty: true
     networks:
       - myNetwork

--- a/entrance-system/Dockerfile
+++ b/entrance-system/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /go/src
 
 # Go Modulesの使用を許可
 ENV GO111MODULE=on
-
 # ローカルのモジュールキャッシュを最適化
 COPY go.mod .
 COPY go.sum .
@@ -18,5 +17,8 @@ COPY . .
 # ポート8080を公開
 EXPOSE 8080
 
+RUN go build -o main cmd/main.go
+
 # 実行可能ファイルをデフォルトのコマンドとして設定
-CMD ["go", "run", "cmd/main.go"]
+#CMD ["go", "run", "cmd/main.go"]
+CMD ["./main"]


### PR DESCRIPTION
- **fix: DockerfileのCMDを修正し、ビルドした実行可能ファイルを使用するように変更**
- **feat: jojihouse-systemのコマンドを設定し、エントリポイントを指定**
- **fix: jojihouse-systemのコマンドを削除し、ボリューム設定を削除**
